### PR TITLE
Kick OLE from OOXML document

### DIFF
--- a/module/module-office/src/main/java/xyz/docbleach/module/ooxml/ContentTypes.java
+++ b/module/module-office/src/main/java/xyz/docbleach/module/ooxml/ContentTypes.java
@@ -1,6 +1,5 @@
 package xyz.docbleach.module.ooxml;
 
-@SuppressWarnings("ALL")
 public final class ContentTypes {
     // Main Parts (PowerPoint)
     public static final String MAIN_PPTX = "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml";
@@ -35,6 +34,8 @@ public final class ContentTypes {
     public static final String ACTIVEX = "application/vnd.ms-office.activeX";
     public static final String OPENXML_ACTIVEX = "application/vnd.openxmlformats-officedocument.activeX";
     public static final String OPENXML_ACTIVEX_XML = "application/vnd.openxmlformats-officedocument.activeX+xml";
+    // Miscellaneous
+    public static final String TEXT_PLAIN = "text/plain";
 
     private ContentTypes() {
         throw new IllegalAccessError("Utility class");

--- a/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
+++ b/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
@@ -1,12 +1,30 @@
 package xyz.docbleach.module.ooxml;
 
+import static xyz.docbleach.api.threat.ThreatBuilder.threat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
 import org.apache.poi.UnsupportedFileFormatException;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
-import org.apache.poi.openxml4j.opc.*;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.openxml4j.opc.PackagePartName;
+import org.apache.poi.openxml4j.opc.PackageRelationship;
+import org.apache.poi.openxml4j.opc.PackagingURIHelper;
+import org.apache.poi.openxml4j.opc.RelationshipSource;
+import org.apache.poi.openxml4j.opc.TargetMode;
 import org.apache.poi.openxml4j.opc.internal.ContentType;
 import org.apache.poi.poifs.filesystem.DocumentFactoryHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import xyz.docbleach.api.BleachSession;
 import xyz.docbleach.api.bleach.Bleach;
 import xyz.docbleach.api.exception.BleachException;
@@ -15,13 +33,6 @@ import xyz.docbleach.api.threat.ThreatAction;
 import xyz.docbleach.api.threat.ThreatSeverity;
 import xyz.docbleach.api.threat.ThreatType;
 import xyz.docbleach.api.util.StreamUtils;
-
-import java.io.*;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
-import static xyz.docbleach.api.threat.ThreatBuilder.threat;
 
 /**
  * Sanitizes Office 2007+ documents (OOXML), in place. This format has two interesting things for
@@ -35,6 +46,10 @@ public class OOXMLBleach implements Bleach {
     private static final String EXTERNAL_RELATION_FORMAT = "Found an external relationship from '{}' to '{}' (type '{}')";
     private static final String OOXWORD_SCHEME = "ooxWord";
 
+    private static final String DUMMY_FILE_PART_NAME = "/bleach/bleach";
+    private static final String DUMMY_FILE_CONTENT = "BLEACHED";
+    private static final PackagePartName DUMMY_PACKAGE_PART_NAME = createPartName(DUMMY_FILE_PART_NAME);
+
     private static final String[] WHITELISTED_RELATIONS = new String[]{
             // Hyperlinks should be safe enough, right?
             Relations.HYPERLINK
@@ -45,6 +60,12 @@ public class OOXMLBleach implements Bleach {
             Relations.VBA_PROJECT,
             Relations.VBA_PROJECT_SIGNATURE,
             Relations.WORD_VBA_DATA,
+
+            // OLE Objects
+            Relations.OPENXML_OLE_OBJECT,
+            Relations.OLE_OBJECT,
+            Relations.E1_OBJECT,
+            Relations.E2_OBJECT,
 
             // ActiveX Controls
             Relations.OPENXML_CONTROL,
@@ -62,6 +83,10 @@ public class OOXMLBleach implements Bleach {
 
             // Blacklisting Postscript to prevent 0days
             ContentTypes.POSTSCRIPT,
+
+            // OLE Objects
+            ContentTypes.OLE_OBJECT,
+            ContentTypes.PACKAGE,
 
             // ActiveX objects
             ContentTypes.ACTIVEX,
@@ -170,9 +195,31 @@ public class OOXMLBleach implements Bleach {
 
             remapContentType(session, part);
         }
+
+        // If threats have been removed, then add the dummy file so the relationship
+        // still refers to an existing dummy object.
+        if (session.threatCount() > 0) {
+        	pushDummyFile(pkg);
+        }
     }
 
-    void remapContentType(BleachSession session, PackagePart part) throws InvalidFormatException {
+    /**
+     * The dummy file tries to prevent Microsoft Office from crashing because they forgot a lot of "!= null"
+     * while checking if a resource is valid.
+     * @param pkg Document to put the file in
+     * @throws InvalidFormatException
+     */
+    private void pushDummyFile(OPCPackage pkg) throws InvalidFormatException {
+        
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+        	bos.write(DUMMY_FILE_CONTENT.getBytes());
+        	pkg.createPart(PackagingURIHelper.createPartName(DUMMY_FILE_PART_NAME), ContentTypes.TEXT_PLAIN, bos);
+        } catch(IOException ex) {
+        	LOGGER.error("Error occured while pushing the file in the document. But, it's not that critical so I'm gonna continue.", ex);
+        }
+	}
+
+	void remapContentType(BleachSession session, PackagePart part) throws InvalidFormatException {
         String oldContentType = part.getContentType();
         if (!REMAPPED_CONTENT_TYPES.containsKey(oldContentType)) {
             return;
@@ -215,8 +262,8 @@ public class OOXMLBleach implements Bleach {
         }
 
         if (isBlacklistedRelationType(relationshipType)) {
-            pkg.removeRelationship(relationship.getId());
-
+        	replaceRelationship(pkg, relationship);
+        
             Threat threat = threat()
                     .type(ThreatType.ACTIVE_CONTENT)
                     .severity(ThreatSeverity.HIGH)
@@ -230,9 +277,9 @@ public class OOXMLBleach implements Bleach {
         }
 
         if (TargetMode.EXTERNAL.equals(relationship.getTargetMode())) {
-            pkg.removeRelationship(relationship.getId());
+            replaceRelationship(pkg, relationship);
+            
             ThreatSeverity severity = ThreatSeverity.HIGH;
-
             if (OOXWORD_SCHEME.equals(relationship.getTargetURI().getScheme())) {
                 // Fake external relationship
                 severity = ThreatSeverity.EXTREME;
@@ -258,7 +305,21 @@ public class OOXMLBleach implements Bleach {
         }
     }
 
-    private boolean isBlacklistedRelationType(String relationshipType) {
+    /**
+     * Replace a relationship by a fake on using the {@link #pushDummyFile(OPCPackage) dummy file} so MS Office does not crash
+     * because the relationship does not exist.
+     * @param pkg Where the relationship must be removed from
+     * @param relationship The relationship to replace
+     * @see #pushDummyFile
+     */
+    private void replaceRelationship(RelationshipSource pkg, PackageRelationship relationship) {
+    	String rId = relationship.getId();
+    	
+    	pkg.removeRelationship(rId);
+    	pkg.addRelationship(DUMMY_PACKAGE_PART_NAME, TargetMode.INTERNAL, Relations.OPENXML_OLE_OBJECT, rId);
+	}
+
+	private boolean isBlacklistedRelationType(String relationshipType) {
         for (String rel : BLACKLISTED_RELATIONS) {
             if (rel.equalsIgnoreCase(relationshipType)) {
                 return true;
@@ -343,5 +404,17 @@ public class OOXMLBleach implements Bleach {
                 LOGGER.error("Unknown content type: {}", contentType);
                 return true;
         }
+    }
+    
+    private static PackagePartName createPartName(final String name) {
+    	PackagePartName res = null;
+    	
+    	try {
+    		res = PackagingURIHelper.createPartName(name);
+    	} catch(InvalidFormatException ex) {
+    		LOGGER.error("Cannot initialize the PackagePartName: ", ex);
+    	}
+    	
+    	return res;
     }
 }

--- a/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
+++ b/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
@@ -185,6 +185,8 @@ public class OOXMLBleach implements Bleach {
         while (it.hasNext()) {
             part = it.next();
             sanitize(session, pkg, part);
+            
+            OOXMLTagHelper.removeExternalDataTag(session, part);
 
             if (!part.isRelationshipPart()) {
                 sanitize(session, part, part.getRelationships());
@@ -203,7 +205,8 @@ public class OOXMLBleach implements Bleach {
         }
     }
 
-    /**
+
+	/**
      * The dummy file tries to prevent Microsoft Office from crashing because they forgot a lot of "!= null"
      * while checking if a resource is valid.
      * @param pkg Document to put the file in

--- a/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLTagHelper.java
+++ b/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLTagHelper.java
@@ -1,0 +1,113 @@
+package xyz.docbleach.module.ooxml;
+
+import static xyz.docbleach.api.threat.ThreatBuilder.threat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.poi.openxml4j.exceptions.InvalidOperationException;
+import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.openxml4j.opc.ZipPackagePart;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import xyz.docbleach.api.BleachSession;
+import xyz.docbleach.api.threat.ThreatAction;
+import xyz.docbleach.api.threat.ThreatSeverity;
+import xyz.docbleach.api.threat.ThreatType;
+
+/**
+ * Helper dedicated to alter XML tags.
+ */
+public class OOXMLTagHelper {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(OOXMLTagHelper.class);
+	
+    private static final String XML_EXTENSION = "xml";
+    private static final String XML_COMMENT_BLEACHED = "<!-- bleached -->";
+    private static final String TAG_EXTERNAL_DATA = "externalData";
+    /** The regexp try to catch the whole tag, including namespace and attributes */
+    private static final String REGEXP_EXTERNAL_DATA = "<.." + TAG_EXTERNAL_DATA + ".*?/>";
+    
+    private OOXMLTagHelper() {
+    }
+    
+    /**
+     * The externalData tag is embedded in xml files to automatically load OLE object or
+     * macro, or any kind of potential threat. Remove this tag prevent MS Office from
+     * crashing. Actually, if you only remove the relation it crashes, that's why you have 
+     * to remove the relation and the reference of the relation (via the externalData tag)
+     * in the xml file.
+     * @param session The current bleach session where the threat can be reported
+     * @param part The package part to sanitize
+     */
+    protected static void removeExternalDataTag(BleachSession session, PackagePart part) {
+    	// Only applicable if the file is an XML file (not a _refs or whatever)
+    	// And is a ZipPackagePart, not a config file or whatever.
+    	if (!XML_EXTENSION.equals(part.getPartName().getExtension()) || !(part instanceof ZipPackagePart)) {
+    		return;
+    	}
+   		
+    	String content = readPartContent(part);
+    	// An error occured
+    	if (content == null) {
+    		return;
+    	}
+    	
+    	// The evil tag has not been found, return
+    	if (content.indexOf(TAG_EXTERNAL_DATA) == -1) {
+    		return;
+    	}
+    	
+    	// Replace the tag by a comment
+    	LOGGER.debug("externalData tag has been spotted {}", part);
+    	content = content.replaceAll(REGEXP_EXTERNAL_DATA, XML_COMMENT_BLEACHED);
+    	
+    	// Write the result
+    	try (OutputStream os = part.getOutputStream()) {
+    		os.write(content.getBytes());
+    		os.close();
+    	} catch (IOException ex) {
+    		LOGGER.error("Error while writing the part content. The file may be corrupted.", ex);
+    		return;
+    	}
+    			
+        session.recordThreat(
+        	threat()
+        		.type(ThreatType.EXTERNAL_CONTENT)
+    		    .severity(ThreatSeverity.HIGH)
+    		    .action(ThreatAction.REMOVE)
+    		    .location(part.getPartName().getName())
+    		    .details("Removed tag \"externalData\" from the document.")
+    		    .build()
+        );
+	}
+    
+	/**
+	 * Read the part content.
+	 * @param part The {@link org.apache.poi.openxml4j.opc.PackagePart PackagePart} the content must be read from
+	 * @return A string containing the content of the part.
+	 */
+    private static String readPartContent(PackagePart part) {
+    	try (InputStream is = part.getInputStream()) {
+    		// Read the file content first
+    		BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+    		
+        	StringBuilder buf = new StringBuilder();
+    		String line = reader.readLine();
+    		while (line != null) {
+    			buf.append(line);
+    			line = reader.readLine();
+    		}
+    		
+    		return buf.toString();
+    	} catch (IOException ex) {
+    		LOGGER.error("Error while bleaching {}. The file may be corrupted :/", part.getPartName().getName(), ex);
+    		return null;
+    	}
+    }
+}


### PR DESCRIPTION
Hey !

I figured out you stopped removing the OLE binary and their relationships in OOXML documents. I understood it was because MS Office was crashing when you remove the relationships.

As it represents a serious threat (several ransomwares are spread using them), I spend some time to find out what was the issue. I found 2 issues:

1. The relationships must target an existing file, if it doesn't, MS Office crashes. So, when a file is removed from the package, I make the relationship to point to a OLE dummy file (although it's a plain text file). The file exists, MS Office loads the dummy OLE, everything's fine.
2. Some package parts are directly loading external data, using the xml tag `externalData`. To prevent any kind of crash, this time, I decided to remove all the occurences of the tag in the parts. No more tag, no more crash.

What do you think about these fixes?

PS: Sorry, I did not put any emoji in my commits. :crying_cat_face: 