### PR TITLE
Don't use unsuported sanitizers

### DIFF
--- a/api/src/main/java/xyz/docbleach/api/BleachSession.java
+++ b/api/src/main/java/xyz/docbleach/api/BleachSession.java
@@ -65,6 +65,9 @@ public class BleachSession implements Serializable {
       if (ongoingTasks++ >= MAX_ONGOING_TASKS) {
         throw new RecursionBleachException(ongoingTasks);
       }
+      if (!bleach.handlesMagic(is)) {
+        return;
+      }
       bleach.sanitize(is, os, this);
     } finally {
       ongoingTasks--;


### PR DESCRIPTION
The BleachSession class can be used either with an aggregate of bleach
(like, CompositeBleach), or with a specific bleach - in this case,
we can't guarantee that the bleach will support our input.