### PR TITLE
Prepare for Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ jdk:
 
 matrix:
   fast_finish: true
-  allow_failures:
-  - jdk: openjdk11
 
 sudo: false
 install: true

--- a/cli/src/main/java/xyz/docbleach/cli/UnsafeSecurityManager.java
+++ b/cli/src/main/java/xyz/docbleach/cli/UnsafeSecurityManager.java
@@ -52,9 +52,4 @@ public class UnsafeSecurityManager extends SecurityManager {
   public void checkExec(String cmd) {
     throw new SecurityException("Exec forbidden.");
   }
-
-  @Override
-  public void checkSystemClipboardAccess() {
-    throw new SecurityException("System Clipboard Access forbidden.");
-  }
 }


### PR DESCRIPTION
- [x] Don't override the `checkSystemClipboardAccess` method in the `Securitymanager`, as it was removed.
- [x] Don't allow Java 11 failures on Travis