### PR TITLE
Remove the SonarCloud integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ sudo: false
 install: true
 
 addons:
-  sonarcloud:
-    organization: "docbleach"
-    token:
-      secure: "ejEHtwUs4Zr0DT8uMbjXl4TiCo6bIMIVm5M6nyLyu+YUNY30TQgpNcJIDqabsHlLan6SMIZEnJ3XAOc6VqkrRDowvPPeXpSAmxcDMQrlvNyzzhBc/CTImXyZqHyjNMsivIdq+j4WQNfUpVAlPGmRacm0AokOsGj5ipo5ofYu5jc3O+6Dz8D77GjE5q91XbujmyoeLb56eF5dpT3AM7UKdStX3OS1RIBffpPuPxOqCuTSoBHIhjtpkmbNkoPMQqQsiC3QXcv604p+cVML3wOk2sDtzVH5EdLHqBFFPD9l36QBicbIXqgMVsSjw0C8fWcvue3S+p3cF3V9R/2NDXMdLV8Euc5Tu/abLNNQDcmlZAe0/Py89pHTtrPzzgixPXzrmxK7r9GckGjyQTypikKWKW3frLD6meDXt5LRSXfohKNHRfZ5hKW9xzVVKAtkRuNBhT1GSdELPXuT2rnzmzTkT/jIMp9HKOyz/TA81uZQM0L6i3W91m+UC8mI3hifh3EvWS1NAnukCtb9MJqXRNBpXhSk3Cf/G3H6m+Jo7c9Vd3o1lvXCsageHyTls9eJk8H3DOdUBazrg7MiqfRPsmvbv9gEoXwzUmLmH6Dj16XJquMvP7d/z/mlEjRoQDLPo6DoYFpVivRS1rBfoP7k8frR46bKqYjWe684mNX1w2zDfZY="
   apt:
     packages:
     - libc6:i386


### PR DESCRIPTION
This SonarCloud integration was unused and didn't provide enough results to warrant a slower CI step.