### PR TITLE
Fix for corrupting Office documents

### DIFF
--- a/api/src/main/java/xyz/docbleach/api/BleachSession.java
+++ b/api/src/main/java/xyz/docbleach/api/BleachSession.java
@@ -65,9 +65,9 @@ public class BleachSession implements Serializable {
       if (ongoingTasks++ >= MAX_ONGOING_TASKS) {
         throw new RecursionBleachException(ongoingTasks);
       }
-      if (!bleach.handlesMagic(is)) {
-        return;
-      }
+      //if (!bleach.handlesMagic(is)) {
+      //  return;
+      //}
       bleach.sanitize(is, os, this);
     } finally {
       ongoingTasks--;


### PR DESCRIPTION
This one makes bleaching possible again, without corrupting (or 0 bytes) almost all files. Just reverting the last change 2 years ago. :S Sorry.