### PR TITLE
Replace relations in documents

### DIFF
--- a/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
+++ b/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
@@ -354,8 +354,8 @@ public class OOXMLBleach implements Bleach {
     String rId = relationship.getId();
     String rRT = relationship.getRelationshipType();
     pkg.removeRelationship(rId);
-	  if (relationship.getTargetMode() !=null){
-  	  pkg.addExternalRelationship(DUMMY_WEB_ADDRESS, rRT, rId);
+	  if (relationship.getTargetMode() != null){
+  	    pkg.addExternalRelationship(DUMMY_WEB_ADDRESS, rRT, rId);
 	  } else {
 	    pkg.addRelationship(DUMMY_PACKAGE_PART_NAME, TargetMode.INTERNAL, rRT, rId);
 	  }

--- a/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
+++ b/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
@@ -354,7 +354,6 @@ public class OOXMLBleach implements Bleach {
     String rId = relationship.getId();
     String rRT = relationship.getRelationshipType();
     pkg.removeRelationship(rId);
-    //pkg.addRelationship(DUMMY_PACKAGE_PART_NAME, TargetMode.INTERNAL, Relations.OPENXML_OLE_OBJECT, rId);
 	  if (relationship.getTargetMode() !=null){
   	  pkg.addExternalRelationship(DUMMY_WEB_ADDRESS, rRT, rId);
 	  } else {

--- a/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
+++ b/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
@@ -351,10 +351,11 @@ public class OOXMLBleach implements Bleach {
    */
   private void replaceRelationship(RelationshipSource pkg, PackageRelationship relationship) {
     String rId = relationship.getId();
-
+    String rRT = relationship.getRelationshipType();
     pkg.removeRelationship(rId);
     pkg.addRelationship(
-        DUMMY_PACKAGE_PART_NAME, TargetMode.INTERNAL, Relations.OPENXML_OLE_OBJECT, rId);
+        //DUMMY_PACKAGE_PART_NAME, TargetMode.INTERNAL, Relations.OPENXML_OLE_OBJECT, rId);
+        DUMMY_PACKAGE_PART_NAME, TargetMode.INTERNAL, rRT, rId);    
   }
 
   private boolean isBlacklistedRelationType(String relationshipType) {

--- a/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
+++ b/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
@@ -354,7 +354,7 @@ public class OOXMLBleach implements Bleach {
     String rId = relationship.getId();
     String rRT = relationship.getRelationshipType();
     pkg.removeRelationship(rId);
-	  if (relationship.getTargetMode() != null){
+	  if (relationship.getTargetMode() == TargetMode.EXTERNAL){
   	    pkg.addExternalRelationship(DUMMY_WEB_ADDRESS, rRT, rId);
 	  } else {
 	    pkg.addRelationship(DUMMY_PACKAGE_PART_NAME, TargetMode.INTERNAL, rRT, rId);

--- a/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
+++ b/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
@@ -354,11 +354,11 @@ public class OOXMLBleach implements Bleach {
     String rId = relationship.getId();
     String rRT = relationship.getRelationshipType();
     pkg.removeRelationship(rId);
-	  if (relationship.getTargetMode() == TargetMode.EXTERNAL){
-  	    pkg.addExternalRelationship(DUMMY_WEB_ADDRESS, rRT, rId);
-	  } else {
-	    pkg.addRelationship(DUMMY_PACKAGE_PART_NAME, TargetMode.INTERNAL, rRT, rId);
-	  }
+    if (relationship.getTargetMode() == TargetMode.EXTERNAL){
+      pkg.addExternalRelationship(DUMMY_WEB_ADDRESS, rRT, rId);
+    } else {
+      pkg.addRelationship(DUMMY_PACKAGE_PART_NAME, TargetMode.INTERNAL, rRT, rId);
+    }
   }
 
   private boolean isBlacklistedRelationType(String relationshipType) {

--- a/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
+++ b/module/module-office/src/main/java/xyz/docbleach/module/ooxml/OOXMLBleach.java
@@ -49,6 +49,7 @@ public class OOXMLBleach implements Bleach {
   private static final String DUMMY_FILE_CONTENT = "BLEACHED";
   private static final PackagePartName DUMMY_PACKAGE_PART_NAME =
       createPartName(DUMMY_FILE_PART_NAME);
+  private static final String DUMMY_WEB_ADDRESS = "https://127.0.0.1/"; 
 
   private static final String[] WHITELISTED_RELATIONS =
       new String[]{
@@ -353,9 +354,12 @@ public class OOXMLBleach implements Bleach {
     String rId = relationship.getId();
     String rRT = relationship.getRelationshipType();
     pkg.removeRelationship(rId);
-    pkg.addRelationship(
-        //DUMMY_PACKAGE_PART_NAME, TargetMode.INTERNAL, Relations.OPENXML_OLE_OBJECT, rId);
-        DUMMY_PACKAGE_PART_NAME, TargetMode.INTERNAL, rRT, rId);    
+    //pkg.addRelationship(DUMMY_PACKAGE_PART_NAME, TargetMode.INTERNAL, Relations.OPENXML_OLE_OBJECT, rId);
+	  if (relationship.getTargetMode() !=null){
+  	  pkg.addExternalRelationship(DUMMY_WEB_ADDRESS, rRT, rId);
+	  } else {
+	    pkg.addRelationship(DUMMY_PACKAGE_PART_NAME, TargetMode.INTERNAL, rRT, rId);
+	  }
   }
 
   private boolean isBlacklistedRelationType(String relationshipType) {


### PR DESCRIPTION
Prevents documents with (hidden) urls to pop-up error messages.
Urls will now be replaced with 127.0.0.1